### PR TITLE
Split on the first colon in language description

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ const visit = require('unist-util-visit');
 
 module.exports = function(options) {
   return (tree) => visit(tree, 'code', (node, index) => {
+    const nodeLang = (node.lang || '');
     let language = '', title = '';
-    let nodeLang = (node.lang || '');
     
     if (nodeLang.includes(':')) {
       language = nodeLang.slice(0, nodeLang.search(':'));

--- a/index.js
+++ b/index.js
@@ -2,7 +2,14 @@ const visit = require('unist-util-visit');
 
 module.exports = function(options) {
   return (tree) => visit(tree, 'code', (node, index) => {
-    const [language, title] = (node.lang || '').split(':');
+    let language = '', title = '';
+    let nodeLang = (node.lang || '');
+    
+    if (nodeLang.includes(':')) {
+      language = nodeLang.slice(0, nodeLang.search(':'));
+      title = nodeLang.slice(nodeLang.search(':') + 1, nodeLang.length);
+    }
+
     if (!title) {
       return;
     }


### PR DESCRIPTION
Earlier implementation split on all colons which caused bug #2 

This change modifies the split method so that the everything after the first colon symbol is considered as title.

Sample output:
<img width="429" alt="Screenshot 2021-04-27 at 11 15 51 PM" src="https://user-images.githubusercontent.com/29686866/116287934-98860480-a7ae-11eb-8a32-0c84d2039299.png">
